### PR TITLE
notify watchers only on transitions

### DIFF
--- a/leader/leader.go
+++ b/leader/leader.go
@@ -197,7 +197,7 @@ func (l *Client) AddWatch(key string, retry time.Duration, valuesC chan string) 
 					continue
 				}
 			}
-			// if nothing has changed and we previously sent this subscriber values,
+			// if nothing has changed and we previously sent this subscriber this value,
 			// do not bother subscriber with extra notifications
 			if re.PrevNode != nil && re.PrevNode.Value == re.Node.Value && sentAnything {
 				continue

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -150,6 +150,7 @@ func (l *Client) AddWatch(key string, retry time.Duration, valuesC chan string) 
 			return
 		}
 
+		var sentAnything bool
 		for {
 			re, err = watcher.Next(ctx)
 			if err == nil {
@@ -196,9 +197,14 @@ func (l *Client) AddWatch(key string, retry time.Duration, valuesC chan string) 
 					continue
 				}
 			}
-
+			// if nothing has changed and we previously sent this subscriber values,
+			// do not bother subscriber with extra notifications
+			if re.PrevNode != nil && re.PrevNode.Value == re.Node.Value && sentAnything {
+				continue
+			}
 			select {
 			case valuesC <- re.Node.Value:
+				sentAnything = true
 			case <-l.closeC:
 				return
 			}


### PR DESCRIPTION
Make sure we notify watchers only on the actual transitions, not all the time when the value is changed to the identical one.
