### PR TITLE
Dmitri/busy loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,3 @@ test:
 	  docker run --name=$(TEST_ETCD_INSTANCE) -p 34001:4001 -p 32380:2380 -p 32379:2379 -d $(TEST_ETCD_IMAGE) -name etcd0 -listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls http://localhost:32379,http://localhost:34001; \
 	fi;
 	COORDINATE_TEST_ETCD_NODES=http://127.0.0.1:34001 go test -v -test.parallel=0 ./...
-

--- a/leader/backoff.go
+++ b/leader/backoff.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
+// NewCountingBackOff returns a new instance of the CountingBackOff
+// with the specified backoff as implementation
 func NewCountingBackOff(backOff backoff.BackOff) *CountingBackOff {
 	return &CountingBackOff{
 		backoff: backOff,
@@ -35,4 +37,49 @@ func (f *CountingBackOff) Reset() {
 // NumTries returns the number of attempts on this backoff counter
 func (f *CountingBackOff) NumTries() int {
 	return f.tries
+}
+
+// NewFlippingBackOff returns a new instance of the FlippingBackOff
+// using regular and failing as backoff implementations
+func NewFlippingBackOff(regular, failing backoff.BackOff) *FlippingBackOff {
+	return &FlippingBackOff{
+		regular: regular,
+		failing: failing,
+	}
+}
+
+// Failing resets the failing state to failing.
+// If failing == false, the failing backoff is reset.
+func (r *FlippingBackOff) Failing(failing bool) {
+	r.isFailing = failing
+	if !failing {
+		r.failing.Reset()
+	}
+}
+
+// NextBackOff returns the duration of the next backoff interval
+func (r *FlippingBackOff) NextBackOff() time.Duration {
+	if r.isFailing {
+		return r.failing.NextBackOff()
+	} else {
+		return r.regular.NextBackOff()
+	}
+}
+
+// Reset resets the underlying backoffs
+func (r *FlippingBackOff) Reset() {
+	r.regular.Reset()
+	r.failing.Reset()
+}
+
+// FlippingBackOff provides a backoff using two backoff implementations.
+// First implementation is used to provide regular spaced notifications,
+// while the second implementation is used to provide notifications if the
+// status has been set to failing.
+// This can be used in conjunction with the backoff.Ticker to provide a custom
+// loop that can dynamically switch to an alternative backoff implementation
+// in case of errors.
+type FlippingBackOff struct {
+	regular, failing backoff.BackOff
+	isFailing        bool
 }

--- a/leader/backoff.go
+++ b/leader/backoff.go
@@ -28,13 +28,13 @@ func (f *CountingBackOff) NextBackOff() time.Duration {
 	return f.backoff.NextBackOff()
 }
 
-// Reset resets the number of tries on this backoff counter to zero
+// Reset resets both the number of steps and the backoff interval to zero
 func (f *CountingBackOff) Reset() {
 	f.tries = 0
 	f.backoff.Reset()
 }
 
-// NumTries returns the number of attempts on this backoff counter
+// NumTries returns the number of steps taken along this backoff interval
 func (f *CountingBackOff) NumTries() int {
 	return f.tries
 }
@@ -49,7 +49,7 @@ func NewFlippingBackOff(regular, failing backoff.BackOff) *FlippingBackOff {
 }
 
 // Failing resets the failing state to failing.
-// If failing == false, the failing backoff is reset.
+// If failing == false, the failing backoff interval is reset.
 func (r *FlippingBackOff) Failing(failing bool) {
 	r.isFailing = failing
 	if !failing {
@@ -66,19 +66,20 @@ func (r *FlippingBackOff) NextBackOff() time.Duration {
 	}
 }
 
-// Reset resets the underlying backoffs
+// Reset resets the underlying backoff intervals
 func (r *FlippingBackOff) Reset() {
 	r.regular.Reset()
 	r.failing.Reset()
 }
 
-// FlippingBackOff provides a backoff using two backoff implementations.
-// First implementation is used to provide regular spaced notifications,
-// while the second implementation is used to provide notifications if the
-// status has been set to failing.
+// FlippingBackOff provides a backoff using two backoff implementations
+// it alternates between.
+// First implementation is used to provide regular notifications,
+// while the second implementation is used to handle errors.
+//
 // This can be used in conjunction with the backoff.Ticker to provide a custom
-// loop that can dynamically switch to an alternative backoff implementation
-// in case of errors.
+// loop that can dynamically switch between backoff implementations
+// depending on state of an operation (e.g. healthy vs experiencing transient errors).
 type FlippingBackOff struct {
 	regular, failing backoff.BackOff
 	isFailing        bool

--- a/leader/backoff.go
+++ b/leader/backoff.go
@@ -6,39 +6,6 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-// NewCountingBackOff returns a new instance of the CountingBackOff
-// with the specified backoff as implementation
-func NewCountingBackOff(backOff backoff.BackOff) *CountingBackOff {
-	return &CountingBackOff{
-		backoff: backOff,
-	}
-}
-
-// CountingBackOff is a backoff that counts the number of taken steps
-type CountingBackOff struct {
-	backoff backoff.BackOff
-
-	// tries describes the number of backoff steps taken
-	tries int
-}
-
-// NextBackOff returns the duration of the next backoff interval
-func (f *CountingBackOff) NextBackOff() time.Duration {
-	f.tries++
-	return f.backoff.NextBackOff()
-}
-
-// Reset resets both the number of steps and the backoff interval to zero
-func (f *CountingBackOff) Reset() {
-	f.tries = 0
-	f.backoff.Reset()
-}
-
-// Tries returns the number of steps taken along this backoff interval
-func (f *CountingBackOff) Tries() int {
-	return f.tries
-}
-
 // NewFlippingBackOff returns a new instance of the FlippingBackOff
 // using regular and failing as backoff implementations
 func NewFlippingBackOff(regular, failing backoff.BackOff) *FlippingBackOff {

--- a/leader/backoff.go
+++ b/leader/backoff.go
@@ -84,3 +84,11 @@ type FlippingBackOff struct {
 	regular, failing backoff.BackOff
 	isFailing        bool
 }
+
+// NewUnlimitedExponentialBackOff returns a new exponential backoff interval
+// w/o time limit
+func NewUnlimitedExponentialBackOff() *backoff.ExponentialBackOff {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = 0
+	return b
+}

--- a/leader/backoff_test.go
+++ b/leader/backoff_test.go
@@ -30,10 +30,10 @@ func (s *BackOffSuite) TestCountsSteps(c *C) {
 
 	backoff.NextBackOff()
 	backoff.NextBackOff()
-	c.Assert(backoff.NumTries(), Equals, 2)
+	c.Assert(backoff.Tries(), Equals, 2)
 
 	backoff.Reset()
-	c.Assert(backoff.NumTries(), Equals, 0)
+	c.Assert(backoff.Tries(), Equals, 0)
 }
 
 func (s *BackOffSuite) TestAlternatesIntervals(c *C) {
@@ -46,11 +46,11 @@ func (s *BackOffSuite) TestAlternatesIntervals(c *C) {
 	backoff.NextBackOff()
 	c.Assert(backoff.NextBackOff(), Equals, 1*time.Second)
 
-	backoff.Failing(true)
+	backoff.SetFailing(true)
 	backoff.NextBackOff()
 	c.Assert(backoff.NextBackOff(), Not(Equals), 1*time.Second)
 
-	backoff.Failing(false)
+	backoff.SetFailing(false)
 	backoff.NextBackOff()
 	c.Assert(backoff.NextBackOff(), Equals, 1*time.Second)
 }

--- a/leader/backoff_test.go
+++ b/leader/backoff_test.go
@@ -23,19 +23,6 @@ func (c *TestClock) Now() time.Time {
 	return t
 }
 
-func (s *BackOffSuite) TestCountsSteps(c *C) {
-	backoff := &CountingBackOff{
-		backoff: backoff.NewExponentialBackOff(),
-	}
-
-	backoff.NextBackOff()
-	backoff.NextBackOff()
-	c.Assert(backoff.Tries(), Equals, 2)
-
-	backoff.Reset()
-	c.Assert(backoff.Tries(), Equals, 0)
-}
-
 func (s *BackOffSuite) TestAlternatesIntervals(c *C) {
 	backoff := NewFlippingBackOff(
 		backoff.NewConstantBackOff(1*time.Second),

--- a/leader/backoff_test.go
+++ b/leader/backoff_test.go
@@ -3,7 +3,7 @@ package leader
 import (
 	"time"
 
-	cbackoff "github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
 	. "gopkg.in/check.v1"
 )
 
@@ -24,27 +24,14 @@ func (c *TestClock) Now() time.Time {
 }
 
 func (s *BackOffSuite) TestBackOff(c *C) {
-	backoff := &FreebieExponentialBackOff{
-		InitialInterval:     500 * time.Millisecond,
-		RandomizationFactor: 0,
-		Multiplier:          2,
-		MaxInterval:         10 * time.Second,
-		MaxElapsedTime:      40 * time.Second,
+	backoff := &CountingBackOff{
+		backoff: backoff.NewExponentialBackOff(),
 	}
 
-	c.Assert(backoff.NextBackOff(), Equals, time.Duration(0))
-	c.Assert(backoff.NextBackOff(), Equals, 500*time.Millisecond)
-	c.Assert(backoff.CurrentTries(), Equals, 2)
+	backoff.NextBackOff()
+	backoff.NextBackOff()
+	c.Assert(backoff.NumTries(), Equals, 2)
 
 	backoff.Reset()
-	c.Assert(backoff.CurrentTries(), Equals, 0)
-	c.Assert(backoff.NextBackOff(), Equals, time.Duration(0))
-	c.Assert(backoff.NextBackOff(), Equals, 500*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, 1000*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, 2000*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, 4000*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, 8000*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, 10000*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, 10000*time.Millisecond)
-	c.Assert(backoff.NextBackOff(), Equals, cbackoff.Stop)
+	c.Assert(backoff.NumTries(), Equals, 0)
 }

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	log "github.com/Sirupsen/logrus"
-	ebackoff "github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
 	"github.com/coreos/etcd/client"
 	"github.com/jonboulle/clockwork"
 )
@@ -48,8 +48,8 @@ type Config struct {
 type Client struct {
 	client client.Client
 	clock  clockwork.Clock
-	closeC chan bool
-	pauseC chan bool
+	closeC chan struct{}
+	pauseC chan struct{}
 	closed uint32
 }
 
@@ -75,8 +75,8 @@ func NewClient(cfg Config) (*Client, error) {
 	return &Client{
 		client: client,
 		clock:  cfg.Clock,
-		closeC: make(chan bool),
-		pauseC: make(chan bool),
+		closeC: make(chan struct{}),
+		pauseC: make(chan struct{}),
 	}, nil
 }
 
@@ -88,10 +88,13 @@ type CallbackFn func(key, prevValue, newValue string)
 // made to the specified key's value. The callback is called with new and
 // previous values for the key. In the first call, both values are the same
 // and reflect the value of the key at that moment
-func (l *Client) AddWatchCallback(key string, retry time.Duration, fn CallbackFn) {
+func (l *Client) AddWatchCallback(ctx context.Context, key string, retry time.Duration, fn CallbackFn) {
 	go func() {
 		valuesC := make(chan string)
-		l.AddWatch(key, retry, valuesC)
+		err := l.AddWatch(ctx, key, retry, valuesC)
+		if err != nil {
+			log.Errorf("watch error: %v", trace.DebugReport(err))
+		}
 		var prev string
 		for {
 			select {
@@ -105,15 +108,18 @@ func (l *Client) AddWatchCallback(key string, retry time.Duration, fn CallbackFn
 	}()
 }
 
-func (l *Client) getWatchAtLatestIndex(ctx context.Context, api client.KeysAPI, key string, retry time.Duration) (client.Watcher, *client.Response, error) {
-	resp, err := l.getFirstValue(key, retry)
+func (l *Client) recreateWatchAtLatestIndex(ctx context.Context, api client.KeysAPI, key string, retry time.Duration) (client.Watcher, *client.Response, error) {
+	prefix := ctx.Value("prefix")
+	resp, err := l.getFirstValue(ctx, key, retry)
 	if err != nil {
-		return nil, nil, trace.BadParameter("%v unexpected error: %v", ctx.Value("prefix"), err)
-	} else if resp == nil {
-		log.Debugf("%v client is closing, return", ctx.Value("prefix"))
+		return nil, nil, trace.Wrap(err, "%v unexpected error", prefix)
+	}
+	if resp == nil {
+		log.Debugf("%v client is closing, return", prefix)
 		return nil, nil, nil
 	}
-	log.Debugf("%v got current value '%v' for key '%v'", ctx.Value("prefix"), resp.Node.Value, key)
+
+	log.Debugf("%v got current value %q for key %q", prefix, resp.Node.Value, key)
 	watcher := api.Watcher(key, &client.WatcherOptions{
 		// Response.Index corresponds to X-Etcd-Index response header field
 		// and is the recommended starting point after a history miss of over
@@ -125,172 +131,213 @@ func (l *Client) getWatchAtLatestIndex(ctx context.Context, api client.KeysAPI, 
 
 // AddWatch starts watching the key for changes and sending them
 // to the valuesC, the watch is stopped
-func (l *Client) AddWatch(key string, retry time.Duration, valuesC chan string) {
-	prefix := fmt.Sprintf("AddWatch(key=%v)", key)
+func (l *Client) AddWatch(ctx context.Context, key string, retry time.Duration, valuesC chan string) error {
 	api := client.NewKeysAPI(l.client)
-
-	go func() {
+	renew := func() (client.Watcher, *client.Response, error) {
+		b := backoff.NewExponentialBackOff()
 		var watcher client.Watcher
 		var resp *client.Response
-		var err error
-
-		ctx, closer := context.WithCancel(context.WithValue(context.Background(), "prefix", prefix))
-		go func() {
-			<-l.closeC
-			closer()
-		}()
-
-		backoff := &FreebieExponentialBackOff{
-			InitialInterval:     500 * time.Millisecond,
-			RandomizationFactor: 0.5,
-			Multiplier:          1.5,
-			MaxInterval:         10 * time.Second,
-			MaxElapsedTime:      30 * time.Second,
-		}
-		ticker := ebackoff.NewTicker(backoff)
-
-		watcher, resp, err = l.getWatchAtLatestIndex(ctx, api, key, retry)
+		err := backoff.Retry(func() (err error) {
+			watcher, resp, err = l.recreateWatchAtLatestIndex(ctx, api, key, retry)
+			return trace.Wrap(err)
+		}, b)
 		if err != nil {
-			return
+			return nil, nil, trace.Wrap(err)
+		}
+		return watcher, resp, nil
+	}
+
+	errC := make(chan error, 1)
+	prefix := fmt.Sprintf("AddWatch(key=%v)", key)
+	go l.watcher(ctx, prefix, renew, valuesC, errC)
+
+	select {
+	case err := <-errC:
+		return trace.Wrap(err)
+	case <-time.After(100 * time.Millisecond):
+		return nil
+	}
+}
+
+func (l *Client) watcher(ctx context.Context, prefix string, renew renewFunc, valuesC chan string, errC chan error) {
+	log.Debug("starting watch")
+
+	var err error
+	watcher, resp, err := renew()
+	if err != nil {
+		errC <- trace.Wrap(err)
+		return
+	}
+
+	if watcher == nil {
+		log.Debug("client is closing")
+		return
+	}
+
+	// FIXME: refactor me
+	// send sends the value from response resp
+	// and returns whether the client should be closed
+	send := func() bool {
+		// do not resend the same value twice
+		if resp.PrevNode != nil && resp.PrevNode.Value == resp.Node.Value {
+			log.Debug("do not send the same value twice")
+			return false
 		}
 
-		// make sure we always send the first actual value
-		if resp != nil && resp.Node != nil {
-			select {
-			case valuesC <- resp.Node.Value:
-			case <-l.closeC:
-				return
-			}
+		log.Debugf("sending value %q", resp.Node.Value)
+		select {
+		case valuesC <- resp.Node.Value:
+		case <-l.closeC:
+			return true
 		}
+		return false
+	}
 
-		var sentAnything bool
-		for {
-			resp, err = watcher.Next(ctx)
-			if err == nil {
-				if resp.Node.Value == "" {
-					log.Debugf("watcher.Next for %v skipping empty value", key)
-					continue
-				}
-				log.Debugf("watcher.Next for %v got %v", key, resp.Node.Value)
-				backoff.Reset()
-			}
-			if err != nil {
-				select {
-				case b := <-ticker.C:
-					log.Debugf("%v backoff %v", prefix, b)
-				}
+	if send() {
+		log.Debug("client is closing")
+		return
+	}
 
-				if err == context.Canceled {
-					log.Debug("client is closing, return")
-					return
-				} else if cerr, ok := err.(*client.ClusterError); ok {
-					if len(cerr.Errors) != 0 && cerr.Errors[0] == context.Canceled {
-						log.Debug("client is closing, return")
-						return
-					}
-					log.Debugf("unexpected cluster error: %v (%v)", err, cerr.Detail())
-					continue
-				} else if IsWatchExpired(err) {
-					log.Debugf("watch index error, resetting watch index: %v", err)
-					watcher, resp, err = l.getWatchAtLatestIndex(ctx, api, key, retry)
-					if err != nil {
-						continue
-					}
-				} else {
-					log.Debugf("unexpected watch error: %v", err)
-					// try recreating the watch if we get repeated unknown errors
-					if backoff.CurrentTries() > 10 {
-						watcher, resp, err = l.getWatchAtLatestIndex(ctx, api, key, retry)
-						if err != nil {
-							continue
-						}
-						backoff.Reset()
-					}
+	b := backoff.NewExponentialBackOff()
+	b.MaxInterval = 10 * time.Second
+	b.MaxElapsedTime = 30 * time.Second
+	backOff := NewCountingBackOff(b)
+	ticker := backoff.NewTicker(backOff)
 
-					continue
-				}
-			}
-			// if nothing has changed and we previously sent this subscriber this value,
-			// do not bother subscriber with extra notifications
-			if resp.PrevNode != nil && resp.PrevNode.Value == resp.Node.Value && sentAnything {
+	for {
+		resp, err = watcher.Next(ctx)
+		log.Debugf("next resp: %+v (%v)", resp, err)
+		if err == nil {
+			backOff.Reset()
+			if resp.Node.Value == "" {
+				log.Debugf("watcher.Next for %q: skipping empty value", prefix)
 				continue
 			}
-			select {
-			case valuesC <- resp.Node.Value:
-				sentAnything = true
-			case <-l.closeC:
+
+			log.Debugf("watcher.Next for %q: got %q", prefix, resp.Node.Value)
+			if send() {
+				log.Debug("client is closing")
 				return
 			}
+			continue
 		}
-	}()
+
+		// FIXME: error handling
+		select {
+		case b := <-ticker.C:
+			log.Debugf("%v backoff %v", prefix, b)
+		}
+
+		if err == context.Canceled {
+			log.Debug("client is closing, return")
+			return
+		} else if cerr, ok := err.(*client.ClusterError); ok {
+			if len(cerr.Errors) != 0 && cerr.Errors[0] == context.Canceled {
+				log.Debug("client is closing, return")
+				return
+			}
+			log.Debugf("unexpected cluster error: %v (%v)", err, cerr.Detail())
+			continue
+		} else if IsWatchExpired(err) {
+			log.Debugf("watch index error, resetting watch index: %v", err)
+			watcher, resp, err = renew()
+			if err != nil {
+				log.Errorf("failed to recreate watch: %v", trace.DebugReport(err))
+			}
+			if watcher == nil {
+				log.Debug("client is closing")
+				return
+			}
+		} else {
+			log.Warningf("unexpected watch error: %v", err)
+			// try recreating the watch if we get repeated unknown errors
+			if backOff.NumTries() > 10 {
+				watcher, resp, err = renew()
+				if err != nil {
+					log.Errorf("failed to re-create watch: %v", trace.DebugReport(err))
+					return
+				}
+				if watcher == nil {
+					log.Debug("client is closing")
+					return
+				}
+				backOff.Reset()
+			}
+
+			continue
+		}
+	}
 }
+
+type renewFunc func() (client.Watcher, *client.Response, error)
 
 // AddVoter starts a goroutine that attempts to set the specified key to
 // to the given value with the time-to-live value specified with term.
-// The time-to-live value cannot be less than a second.
+// The term cannot be less than a second.
 // After successfully setting the key, it attempts to renew the lease for the specified
 // term indefinitely
-func (l *Client) AddVoter(context context.Context, key, value string, term time.Duration) error {
+func (l *Client) AddVoter(ctx context.Context, key, value string, term time.Duration) error {
 	if value == "" {
 		return trace.BadParameter("voter value for key cannot be empty")
 	}
 	if term < time.Second {
 		return trace.BadParameter("term cannot be < 1s")
 	}
-	go func() {
-		err := l.elect(key, value, term)
-		if err != nil {
-			log.Debugf("voter error: %v", err)
-		}
-		ticker := time.NewTicker(term / 5)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-l.pauseC:
-				log.Debug("was asked to step down, pausing heartbeat")
-				select {
-				case <-time.After(term * 2):
-				case <-l.closeC:
-					log.Debug("client is closing, return")
-					return
-				case <-context.Done():
-					log.Debugf("removing voter for %v", value)
-					return
-				}
-			default:
-			}
 
+	go l.voter(ctx, key, value, term)
+	return nil
+}
+
+func (l *Client) voter(ctx context.Context, key, value string, term time.Duration) {
+	err := l.elect(ctx, key, value, term)
+	// TODO: exponential back off on errors
+	if err != nil {
+		log.Debugf("voter error: %v", err)
+	}
+	ticker := time.NewTicker(term / 5)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.pauseC:
+			log.Debug("was asked to step down, pausing heartbeat")
 			select {
-			case <-ticker.C:
-				err := l.elect(key, value, term)
-				if err != nil {
-					log.Debugf("voter error: %v", err)
-				}
+			case <-time.After(term * 2):
 			case <-l.closeC:
 				log.Debug("client is closing, return")
 				return
-			case <-context.Done():
+			case <-ctx.Done():
 				log.Debugf("removing voter for %v", value)
 				return
 			}
+		case <-ticker.C:
+			log.Debugf("electing %q", value)
+			err := l.elect(ctx, key, value, term)
+			if err != nil {
+				log.Debugf("voter error: %v", err)
+			}
+		case <-l.closeC:
+			log.Debug("client is closing, return")
+			return
+		case <-ctx.Done():
+			log.Debugf("removing voter for %v", value)
+			return
 		}
-	}()
-	return nil
+	}
 }
 
 // StepDown makes this participant to pause his attempts to re-elect itself thus giving up its leadership
 func (l *Client) StepDown() {
-	l.pauseC <- true
+	l.pauseC <- struct{}{}
 }
 
 // getFirstValue returns the current value for key if it exists, or waits
 // for the value to appear and loops until client.Close is called
-func (l *Client) getFirstValue(key string, retryPeriod time.Duration) (*client.Response, error) {
+func (l *Client) getFirstValue(ctx context.Context, key string, retryPeriod time.Duration) (*client.Response, error) {
 	api := client.NewKeysAPI(l.client)
 	tick := time.NewTicker(retryPeriod)
 	defer tick.Stop()
 	for {
-		resp, err := api.Get(context.TODO(), key, nil)
+		resp, err := api.Get(ctx, key, nil)
 		if err == nil {
 			return resp, nil
 		} else if !IsNotFound(err) {
@@ -308,29 +355,29 @@ func (l *Client) getFirstValue(key string, retryPeriod time.Duration) (*client.R
 // elect is taken from: https://github.com/kubernetes/contrib/blob/master/pod-master/podmaster.go
 // this is a slightly modified version though, that does not return the result
 // instead we rely on watchers
-func (l *Client) elect(key, value string, term time.Duration) error {
+func (l *Client) elect(ctx context.Context, key, value string, term time.Duration) error {
 	candidate := fmt.Sprintf("candidate(key=%v, value=%v, term=%v)", key, value, term)
 	log.Debugf("%v start", candidate)
 	api := client.NewKeysAPI(l.client)
-	resp, err := api.Get(context.TODO(), key, nil)
+	resp, err := api.Get(ctx, key, nil)
 	if err != nil {
 		if !IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		log.Debugf("%v key not found, try to elect myself", candidate)
+		log.Debugf("%q key not found, try to elect myself", candidate)
 		// try to grab the lock for the given term
-		_, err := api.Set(context.TODO(), key, value, &client.SetOptions{
+		_, err := api.Set(ctx, key, value, &client.SetOptions{
 			TTL:       term,
 			PrevExist: client.PrevNoExist,
 		})
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		log.Debugf("%v successfully elected", candidate)
+		log.Debugf("%q successfully elected", candidate)
 		return nil
 	}
 	if resp.Node.Value != value {
-		log.Debugf("%v: leader is %v, try again", candidate, resp.Node.Value)
+		log.Debugf("%q: leader is %q, try again", candidate, resp.Node.Value)
 		return nil
 	}
 	if resp.Node.Expiration.Sub(l.clock.Now().UTC()) > time.Duration(term/2) {
@@ -338,7 +385,7 @@ func (l *Client) elect(key, value string, term time.Duration) error {
 	}
 
 	// extend the lease before the current expries
-	_, err = api.Set(context.TODO(), key, value, &client.SetOptions{
+	_, err = api.Set(ctx, key, value, &client.SetOptions{
 		TTL:       term,
 		PrevValue: value,
 		PrevIndex: resp.Node.ModifiedIndex,
@@ -346,7 +393,7 @@ func (l *Client) elect(key, value string, term time.Duration) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	log.Debugf("%v extended lease", candidate)
+	log.Debugf("%q extended lease", candidate)
 	return nil
 }
 

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -317,7 +317,6 @@ func (l *Client) elect(ctx context.Context, key, value string, term time.Duratio
 		return nil
 	}
 	if resp.Node.Value != value {
-		log.Debugf("leader is %q, try again", resp.Node.Value)
 		return nil
 	}
 	if resp.Node.Expiration.Sub(l.clock.Now().UTC()) > time.Duration(term/2) {

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -204,7 +204,7 @@ func (l *Client) watcher(ctx context.Context, prefix string, renew renewFunc, va
 
 		select {
 		case b := <-ticker.C:
-			log.Debugf("backoff %v", prefix, b)
+			log.Debugf("backoff %v", b)
 		case <-ctx.Done():
 			return
 		case <-l.closeC:
@@ -313,7 +313,7 @@ func (l *Client) StepDown() {
 // instead we rely on watchers
 func (l *Client) elect(ctx context.Context, key, value string, term time.Duration) error {
 	candidate := fmt.Sprintf("candidate(key=%v, value=%v, term=%v)", key, value, term)
-	log := log.WithFields(log.Fields{"candiate": candidate})
+	log := log.WithFields(log.Fields{"candidate": candidate})
 
 	api := client.NewKeysAPI(l.client)
 	resp, err := api.Get(ctx, key, nil)

--- a/leader/leader_test.go
+++ b/leader/leader_test.go
@@ -26,6 +26,7 @@ var _ = Suite(&LeaderSuite{})
 
 func (s *LeaderSuite) SetUpSuite(c *C) {
 	log.SetOutput(os.Stderr)
+	log.SetLevel(log.DebugLevel)
 	nodesString := os.Getenv("COORDINATE_TEST_ETCD_NODES")
 	if nodesString == "" {
 		// Skips the entire suite
@@ -60,7 +61,7 @@ func (s *LeaderSuite) TestLeaderElectSingle(c *C) {
 	key := fmt.Sprintf("/planet/tests/elect/%v", uuid.New())
 
 	changeC := make(chan string)
-	clt.AddWatchCallback(key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+	clt.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
 		changeC <- newVal
 	})
 	clt.AddVoter(context.TODO(), key, "node1", time.Second)
@@ -80,7 +81,7 @@ func (s *LeaderSuite) TestReceiveExistingValue(c *C) {
 	key := fmt.Sprintf("/planet/tests/elect/%v", uuid.New())
 
 	changeC := make(chan string)
-	clt.AddWatchCallback(key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+	clt.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
 		changeC <- newVal
 	})
 	api := client.NewKeysAPI(clt.client)
@@ -104,7 +105,7 @@ func (s *LeaderSuite) TestLeaderTakeover(c *C) {
 	key := fmt.Sprintf("/planet/tests/elect/%v", uuid.New())
 
 	changeC := make(chan string)
-	cltb.AddWatchCallback(key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+	cltb.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
 		changeC <- newVal
 	})
 	clta.AddVoter(context.TODO(), key, "voter a", time.Second)
@@ -141,7 +142,7 @@ func (s *LeaderSuite) TestLeaderReelectionWithSingleClient(c *C) {
 	key := fmt.Sprintf("/planet/tests/elect/%v", uuid.New())
 
 	changeC := make(chan string)
-	clt.AddWatchCallback(key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+	clt.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
 		changeC <- newVal
 	})
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -199,15 +200,16 @@ func (s *LeaderSuite) TestHandleLostIndex(c *C) {
 	kapi := client.NewKeysAPI(clt.client)
 
 	changeC := make(chan string)
-	clt.AddWatchCallback(key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+	clt.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+		log.Debugf("prev: %v, new: %v", prevVal, newVal)
 		changeC <- newVal
 	})
 
 	last := ""
-	log.Info("setting our key 1100 times")
-	for i := 0; i < 1100; i++ {
+	log.Info("setting our key 5 times")
+	for i := 0; i < 50; i++ {
 		val := fmt.Sprintf("%v", uuid.New())
-		kapi.Set(context.Background(), key, val, nil)
+		kapi.Set(context.TODO(), key, val, nil)
 		last = val
 	}
 
@@ -219,7 +221,7 @@ func (s *LeaderSuite) TestHandleLostIndex(c *C) {
 				log.Infof("got expected final value from watch")
 				return
 			}
-		case <-time.After(20 * time.Second):
+		case <-time.After(1 * time.Second):
 			c.Fatalf("never got anticipated last value from watch")
 		}
 	}
@@ -235,7 +237,7 @@ func (s *LeaderSuite) TestStepDown(c *C) {
 	key := fmt.Sprintf("/planet/tests/elect/%v", uuid.New())
 
 	changeC := make(chan string)
-	cltb.AddWatchCallback(key, 50*time.Millisecond, func(key, prevVal, newVal string) {
+	cltb.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
 		changeC <- newVal
 	})
 

--- a/leader/leader_test.go
+++ b/leader/leader_test.go
@@ -26,7 +26,6 @@ var _ = Suite(&LeaderSuite{})
 
 func (s *LeaderSuite) SetUpSuite(c *C) {
 	log.SetOutput(os.Stderr)
-	log.SetLevel(log.DebugLevel)
 	nodesString := os.Getenv("COORDINATE_TEST_ETCD_NODES")
 	if nodesString == "" {
 		// Skips the entire suite
@@ -201,13 +200,12 @@ func (s *LeaderSuite) TestHandleLostIndex(c *C) {
 
 	changeC := make(chan string)
 	clt.AddWatchCallback(context.TODO(), key, 50*time.Millisecond, func(key, prevVal, newVal string) {
-		log.Debugf("prev: %v, new: %v", prevVal, newVal)
 		changeC <- newVal
 	})
 
 	last := ""
-	log.Info("setting our key 5 times")
-	for i := 0; i < 50; i++ {
+	log.Info("setting our key 1100 times")
+	for i := 0; i < 1100; i++ {
 		val := fmt.Sprintf("%v", uuid.New())
 		kapi.Set(context.TODO(), key, val, nil)
 		last = val
@@ -216,7 +214,6 @@ func (s *LeaderSuite) TestHandleLostIndex(c *C) {
 	for {
 		select {
 		case val := <-changeC:
-			log.Infof("got value: %s last: %s", val, last)
 			if val == last {
 				log.Infof("got expected final value from watch")
 				return


### PR DESCRIPTION
 - Update [backoff](https://github.com/cenkalti/backoff) package reference.
 - Use backoff loops w/o time restriction to avoid busy looping after the `MaxElaspedTime` has elapsed.
 - Simplify the implementation and avoid issues with potential use of null-pointers on retries
 - Use `context` where appropriate