### PR TITLE
Overhaul leader election logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 
-TEST_ETCD_IMAGE := quay.io/coreos/etcd:v2.3.7
+TEST_ETCD_IMAGE := quay.io/coreos/etcd:v3.3.1
 TEST_ETCD_INSTANCE := coordinate0
 
 test:
@@ -12,7 +12,6 @@ test:
 	  if [ "$$etcd_instance" != "" ]; then \
 	    docker rm -v $$etcd_instance; \
 	  fi; \
-	  docker run --name=$(TEST_ETCD_INSTANCE) -p 34001:4001 -p 32380:2380 -p 32379:2379 -d $(TEST_ETCD_IMAGE) -name etcd0 -listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls http://localhost:32379,http://localhost:34001; \
+	  docker run --name=$(TEST_ETCD_INSTANCE) -p 34001:4001 -p 32380:2380 -p 32379:2379 -d $(TEST_ETCD_IMAGE) etcd -name etcd0 -listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls http://localhost:32379,http://localhost:34001; \
 	fi;
-	COORDINATE_TEST_ETCD_NODES=http://127.0.0.1:34001 go test -v -test.parallel=0 ./...
-
+	COORDINATE_TEST_ETCD_NODES=http://127.0.0.1:34001 go test -v ./...

--- a/leader/leader_test.go
+++ b/leader/leader_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/gravitational/coordinate/config"
 
-	"github.com/coreos/etcd/client"
 	"github.com/pborman/uuid"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/client"
 	. "gopkg.in/check.v1"
 )
 
@@ -25,7 +25,7 @@ type LeaderSuite struct {
 var _ = Suite(&LeaderSuite{})
 
 func (s *LeaderSuite) SetUpSuite(c *C) {
-	log.SetOutput(os.Stderr)
+	logrus.SetOutput(os.Stderr)
 	nodesString := os.Getenv("COORDINATE_TEST_ETCD_NODES")
 	if nodesString == "" {
 		// Skips the entire suite


### PR DESCRIPTION
Make logging this library does more useful to provide insight into what's actually going on during the runtime.

Before, it barely logged anything and in certain cases even errors were being silently dropped. I tried to make it log only helpful stuff though to reduce noise so for example it doesn't log when the lease renews cause it happens constantly, but it does log when a lease is acquired anew.

This is sort of in response to https://github.com/gravitational/gravity/issues/1091 where the root cause of the hung leader election can't be determined due to inadequate logging.