### PR TITLE
Minor tweaks

### DIFF
--- a/leader/leader.go
+++ b/leader/leader.go
@@ -108,9 +108,14 @@ func (l *Client) AddWatchCallback(key string, fn CallbackFn) {
 	go func() {
 		defer l.wg.Done()
 		var prev string
-		for val := range valuesC {
-			fn(ctx, key, prev, val)
-			prev = val
+		for {
+			select {
+			case val := <-valuesC:
+				fn(ctx, key, prev, val)
+				prev = val
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 	go func() {

--- a/leader/leader_test.go
+++ b/leader/leader_test.go
@@ -294,16 +294,19 @@ func (s *LeaderSuite) TestCanSetupMultipleWatchesOnKey(c *C) {
 }
 
 func receiver(ch chan<- string) CallbackFn {
-	return func(key, prevVal, newVal string) {
+	return func(ctx context.Context, key, prevVal, newVal string) {
 		if newVal == "" || prevVal == newVal {
 			return
 		}
-		ch <- newVal
+		select {
+		case ch <- newVal:
+		case <-ctx.Done():
+		}
 	}
 }
 
 func droppingReceiver(ch chan string) CallbackFn {
-	return func(key, prevVal, newVal string) {
+	return func(ctx context.Context, key, prevVal, newVal string) {
 		if newVal == "" || prevVal == newVal {
 			return
 		}
@@ -311,6 +314,9 @@ func droppingReceiver(ch chan string) CallbackFn {
 		case <-ch:
 		default:
 		}
-		ch <- newVal
+		select {
+		case ch <- newVal:
+		case <-ctx.Done():
+		}
 	}
 }


### PR DESCRIPTION
Have `AddWatchCallback` cancel the callback if the client receives close event.
Update the callback function signature to accept a context for proper life-time tracking.